### PR TITLE
Replace  variable name'value' with 'values'

### DIFF
--- a/data/part-3/1-discovering-errors.md
+++ b/data/part-3/1-discovering-errors.md
@@ -86,7 +86,7 @@ while (true) {
 if (sum == 0) {
     System.out.println("The average of the values could not be calculated.");
 } else {
-    System.out.println("Average of values: " + (1.0 * sum / value));
+    System.out.println("Average of values: " + (1.0 * sum / values));
 }
 ```
 
@@ -258,7 +258,7 @@ while (true) {
 if (sum == 0) {
     System.out.println("The average of the values could not be calculated.");
 } else {
-    System.out.println("Average of values: " + (1.0 * sum / value));
+    System.out.println("Average of values: " + (1.0 * sum / values));
 }
 ```
 
@@ -322,7 +322,7 @@ System.out.println("-- values: " + values + ", sum: " + sum);
 if (sum == 0) {
     System.out.println("The average of the values could not be calculated.");
 } else {
-    System.out.println("Average of values: " + (1.0 * sum / value));
+    System.out.println("Average of values: " + (1.0 * sum / values));
 }
 ```
 


### PR DESCRIPTION
I noticed that variable name **value** in examples in part 3-1 is out of scope making IDE unable to compile this code. 

Change from
```java
System.out.println("Average of values: " + (1.0 * sum / value));
```

to
```java
System.out.println("Average of values: " + (1.0 * sum / values));
```