### PR TITLE
Suggestion for Part-1/4-variables example

### DIFF
--- a/data/part-1/2-printing.md
+++ b/data/part-1/2-printing.md
@@ -548,4 +548,4 @@ public class Comments {
 }
 ```
 
-The last line of the example shows a particularly handy use-case for comments. Code that has been written does not need to eb deleted to try out something else.
+The last line of the example shows a particularly handy use-case for comments. Code that has been written does not need to be deleted to try out something else.

--- a/data/part-1/2-printing.md
+++ b/data/part-1/2-printing.md
@@ -548,4 +548,4 @@ public class Comments {
 }
 ```
 
-The last line of the example shows a particularly handy use-case for comments. Code that has been written does not need to be deleted to try out something else.
+The last line of the example shows a particularly handy use-case for comments. Code that has been written does not need to eb deleted to try out something else.

--- a/data/part-1/4-variables.md
+++ b/data/part-1/4-variables.md
@@ -489,8 +489,8 @@ int camelCase = 5; // Ei sallittu -- muuttuja camelCase on jo käytössä!
 ``` -->
 
 ```java
-int 7variable = 4; // Not Allowed!
-int variable7 = 4; // Allowed, but not a descriptive variable name
+int System.out.print = 4; // Not Allowed!
+int System.out.println = 4; // Not Allowed!
 ```
 
 ```java

--- a/data/part-1/4-variables.md
+++ b/data/part-1/4-variables.md
@@ -533,7 +533,7 @@ Letters containing diacritics (e.g. the letters ä and ö used in Finnish) shoul
 
 <!-- Muuttujan tyyppi kerrotaan muuttujan esittelyn yhteydessä. Esimerkiksi merkkijonon "teksti" sisältävä merkkijonomuuttuja luodaan lauseella `String merkkijono = "teksti";` ja kokonaisluvun 42 sisältävä kokonaislukumuuttuja luodaan lauseella `int luku = 42;`. -->
 
-A variable's type is specificed when it's initally declared. For example, a variable containing the string "text" is declared with the statement `String string = "text";`, and an integer having the value 42 is declared with the statement `int value = 42;`. -->
+A variable's type is specified when it's initally declared. For example, a variable containing the string "text" is declared with the statement `String string = "text";`, and an integer having the value 42 is declared with the statement `int value = 42;`. -->
 
 <!-- Muuttujan tyyppi määrää arvot, joita muuttuja voi saada. `String`-tyyppiset muuttujat saavat arvokseen merkkijonoja, `int`-tyyppiset muuttujat saavat arvokseen kokonaislukuja, `double`-tyyppiset muuttujat saavat arvokseen liukulukuja, ja `boolean`-tyyppiset muuttujat saavat arvokseen totuusarvoja. -->
 


### PR DESCRIPTION
Has a repeat for an example on what variable names should/shouldn't look like.

```java
int 7variable = 4; // Not Allowed!
int variable7 = 4; // Allowed, but not a descriptive variable name
```

is repeated twice, despite the paragraph talking about not naming variables using commands provided by Java instead. I replaced it with names ```System.out.print``` and ```System.out.println``` since those were the examples given. Though in reality, even if they were commands provided by Java, they still wouldn't work as variable names due to having periods in them. Maybe other commands or keywords would be a better example, i.e. ```new```.

I noticed the same issue in the Finnish code as well -- it was repeated twice.

Also fixed a typo I found.

Feel free to leave comments or change as needed. 