### PR TITLE
Fixing Typos in Part-2 / 4-Methods

### DIFF
--- a/data/part-1/2-printing.md
+++ b/data/part-1/2-printing.md
@@ -548,4 +548,4 @@ public class Comments {
 }
 ```
 
-The last line of the example shows a particularly handy use-case for comments. Code that has been written does not need to eb deleted to try out something else.
+The last line of the example shows a particularly handy use-case for comments. Code that has been written does not need to be deleted to try out something else.

--- a/data/part-1/2-printing.md
+++ b/data/part-1/2-printing.md
@@ -548,4 +548,4 @@ public class Comments {
 }
 ```
 
-The last line of the example shows a particularly handy use-case for comments. Code that has been written does not need to be deleted to try out something else.
+The last line of the example shows a particularly handy use-case for comments. Code that has been written does not need to eb deleted to try out something else.

--- a/data/part-2/4-methods.md
+++ b/data/part-2/4-methods.md
@@ -2269,6 +2269,6 @@ The call `christmasTree(10)` should print:
 
 <!-- **Huom:** korkeuksien jotka ovat alle 3 ei tarvitse toimia! -->
 
-**NB:** heights shorter that 3 don't have work correctly!
+**NB:** heights shorter than 3 don't have to work correctly!
 
 </programming-exercise>


### PR DESCRIPTION
heights shorter that 3 don't have work correctly! 
->
heights shorter than 3 don't have to work correctly!