### PR TITLE
Fix typo in Part 5 - 4 Objects and references

### DIFF
--- a/data/part-5/4-objects-and-references.md
+++ b/data/part-5/4-objects-and-references.md
@@ -2469,8 +2469,8 @@ Apartment manhattanStudioApt = new Apartment(1, 16, 5500);
 Apartment atlantaTwoBedroomApt = new Apartment(2, 38, 4200);
 Apartment bangorThreeBedroomApt = new Apartment(3, 78, 2500);
 
-System.out.println(manhattanStudioApt.moreExpensiveThan(atlantaTwoBedroomApt));  // true
-System.out.println(bangorThreeBedroomApt.moreExpensiveThan(atlantaTwoBedroomApt));   // false
+System.out.println(manhattanStudioApt.moreExpensiveThan(atlantaTwoBedroomApt));  // false
+System.out.println(bangorThreeBedroomApt.moreExpensiveThan(atlantaTwoBedroomApt));   // true
 ```
 
 </programming-exercise>


### PR DESCRIPTION
In the assignment Comparing Appartments, the english version of the last part, "More expensive". Had the comments for the "correct output" reversed.
I flipped the order, and it is now correct.