### PR TITLE
Update 2-packages.md

### DIFF
--- a/data/part-11/2-packages.md
+++ b/data/part-11/2-packages.md
@@ -1356,6 +1356,7 @@ Valitse toiminto:
 
 Airport Asset Control
 --------------------
+Airport Asset Control
 
 Choose an action:
 [1] Add an airplane
@@ -1403,6 +1404,7 @@ Choose an action:
 
 Flight Control
 ------------
+Flight Control
 
 Choose an action:
 [1] Print airplanes
@@ -1418,9 +1420,9 @@ Choose an action:
 [3] Print airplane details
 [x] Quit
 &gt; **2**
-HA-LOL (42 passengers) (HEL-BAL)
-HA-LOL (42 passengers) (BAL-HEL)
-G-OWAC (101 passengers) (JFK-BAL)
+HA-LOL (42 capacity) (HEL-BAL)
+HA-LOL (42 capacity) (BAL-HEL)
+G-OWAC (101 capacity) (JFK-BAL)
 
 Choose an action:
 [1] Print airplanes

--- a/data/part-11/2-packages.md
+++ b/data/part-11/2-packages.md
@@ -1356,8 +1356,6 @@ Valitse toiminto:
 
 Airport Asset Control
 --------------------
-Airport Asset Control
-
 Choose an action:
 [1] Add an airplane
 [2] Add a flight
@@ -1404,8 +1402,6 @@ Choose an action:
 
 Flight Control
 ------------
-Flight Control
-
 Choose an action:
 [1] Print airplanes
 [2] Print flights


### PR DESCRIPTION
-ln.1359 added output "Airport Asset Control". In my testing I noticed if we don't print this, tests fail.
-ln.1407 added output "Flight Control". Again, we should be printing this for testing.
-lines 1423-1425 changed "passengers" to "capacity" as testing does not seem to accept the term passengers as a correct output.