### PR TITLE
part-7_08_BigYear. Typo

### DIFF
--- a/data/part-7/3-larger-exercises.md
+++ b/data/part-7/3-larger-exercises.md
@@ -737,7 +737,7 @@ Crow (Corvus Corvus): 0 observations
 ? **One**
 Bird? **Hawk**
 Hawk (Dorkus Dorkus): 2 observations
-? **Lopeta**
+? **Quit**
 
 </sample-output>
 


### PR DESCRIPTION
Part07_08.BigYear had a Finish word for "Quit" now in English, which I updated it to be English when the mainProgram is displayed for the demonstration.