### PR TITLE
Fix code error in part-3/2-lists

### DIFF
--- a/data/part-3/2-lists.md
+++ b/data/part-3/2-lists.md
@@ -860,7 +860,7 @@ if (index < teachers.size()) {
     index = index + 1; // index = 4
 }
 
-if (index < index.size()) {
+if (index < teachers.size()) {
     // this will not be executed since index = 4 and teachers.size() = 4
     System.out.println(teachers.get(index));
     index = index + 1;


### PR DESCRIPTION
Code example in topic: Iterating Over a List Continued from part-3/2-lists
`index` is an integer variable used for iterating over a list `teachers`.

Change code from:
`if (index < index.size()) {`

To:
`if (index < teachers.size()) {`