### PR TITLE
Typo and confusing statement fix

### DIFF
--- a/data/part-1/6-conditional-statements.md
+++ b/data/part-1/6-conditional-statements.md
@@ -476,8 +476,10 @@ Greater number is: 8
 
 <sample-output>
 
-Give the first number; **5**
-Give the second number: **5**
+Give the first number:
+**5**
+Give the second number:
+**5**
 The numbers are equal!
 
 </sample-output>
@@ -1167,13 +1169,13 @@ int number = 7;
 if (!(number > 4)) {
     System.out.println("The number is not greater than 4.");
 } else {
-    System.out.println("The number is greater than or equal to 4.")
+    System.out.println("The number is greater than 4.")
 }
 ```
 
 <sample-output>
 
-The number is greater than or equal to 4.
+The number is greater than 4.
 
 </sample-output>
 
@@ -1534,7 +1536,7 @@ When a gift is given by a close relative or a family member, the amount of gift 
 
 <!-- Esimerkiksi 6000 euron lahjasta tulee maksaa veroa 180 euroa (100 + (6000-5000) * 0.08), ja 75000 euron lahjasta tulee maksaa veroa 7100 euroa (4700 + (75000-55000) * 0.12). -->
 
-For example 6000€ gift implies 180€ of gift tax (100 + (6000-5000)_0.08), and 75000€ gift implies 7100€ of gift tax (4700 + (75000-55000) _ 0.12).
+For example 6000€ gift implies 180€ of gift tax (100 + (6000-5000) * 0.08), and 75000€ gift implies 7100€ of gift tax (4700 + (75000-55000) * 0.12).
 
 <!-- Tee ohjelma, joka laskee lahjaveron lähimmiltä sukulaisilta annetulle lahjalle. Alla on muutama esimerkki ohjelman toiminnasta. -->
 


### PR DESCRIPTION
Fixed 2 typo and a printed statement for an exercise that may confuse learners. 

```
int number = 7;

if (!(number > 4)) {
    System.out.println("The number is not greater than 4.");
} else {
    System.out.println("The number is greater than or equal to 4.")
}
```

The program prints `The number is greater than or equal to 4.` when the expression `!(number > 4)` is false, however the boolean result for when the number is 4 is actually true, i.e. `!(4 > 4)` is `true` and not false. 

Although this does not make the program fail nor is it a false statement, and that for a `or` operator all we need is one side to be true for the whole expression to be true, this still may lead some learners to think that when `!(number > 4) == false` there is a possible case that `number == 4`.

Therefore I propose to correct the text.
