### PR TITLE
Use class HealthStation insteadof HealthInstitution

### DIFF
--- a/data/part-5/4-objects-and-references.md
+++ b/data/part-5/4-objects-and-references.md
@@ -1067,7 +1067,7 @@ public static void main(String[] args) {
 ```java
 public static void main(String[] args) {
 
-    HealthStation childrensHospital = new HealthInstitution();
+    HealthStation childrensHospital = new HealthStation();
 
     Person ethan = new Person("Ethan", 1, 110, 7);
     Person peter = new Person("Peter", 33, 176, 85);


### PR DESCRIPTION
In "Programming exercise: Health station (3 parts)", 
specifically "Part 3: Counting weighings", in the code
example, after the main declaration a HealthStation is
instantiated but instead of use the class HealthStation
it uses a class named  "HealthInstitution".