### PR TITLE
Clarified instructions for Exercise - Double Input

### DIFF
--- a/data/part-1/4-variables.md
+++ b/data/part-1/4-variables.md
@@ -847,7 +847,7 @@ You wrote 18.0
 <!-- Kirjoita ohjelma, joka kysyy käyttäjältä liukulukua. Tämän jälkeen ohjelma tulostaa käyttäjän syöttämän luvun.
 Alla on annettuna ohjelman esimerkkitulostuksia: -->
 
-Write a program that asks the user for a floating-point number. The program then prints the user's input value.
+Write a program that asks the user for a floating-point number using the variable type Double. The program then prints the user's input value.
 
 Example prints for the program can be seen below:
 


### PR DESCRIPTION
added further clarification for Exercise - Double Input to clearly state to use the variable type Double.

The last TMC test won't accept using the Float point variable and saying "asks users for a floating-point number" can be ambiguous.