### PR TITLE
Fixed missing "class" keyword in Part 5 - Objects and references on line 3541

### DIFF
--- a/data/part-5/4-objects-and-references.md
+++ b/data/part-5/4-objects-and-references.md
@@ -3538,7 +3538,7 @@ public Laskuri {
 ``` -->
 
 ```java
-public Counter {
+public class Counter {
     private int value;
 
     // example of using multiple constructors:


### PR DESCRIPTION
![Screenshot 2021-12-29 064753](https://user-images.githubusercontent.com/31277910/147618828-e8f5869c-f219-453e-8e70-04dd22f20046.png)
