### PR TITLE
Correct "beed" typo to "been"

### DIFF
--- a/data/part-3/2-lists.md
+++ b/data/part-3/2-lists.md
@@ -61,7 +61,7 @@ Programming languages offer tools to assist in storing a large quantity of value
 
 <!-- ArrayList on Javan valmiiksi tarjoama työväline listojen käsittelyyn. Se tarjoaa metodit muunmuassa arvojen lisäämiseen listalle, arvojen poistamiseen listalta sekä arvojen hakemiseen tietystä listan kohdasta. Listan konkreettinen toiminta -- eli miten lista on oikeasti ohjelmoitu -- on abstrahoitu metodien taakse, jolloin listaa käyttävän ohjelmoijan ei tarvitse välittää listan sisäisestä toiminnallisuudesta. -->
 
-ArrayList is a pre-made tool in Java that helps dealing with lists. It offers various methods, including ones for adding values to the list, removing values from it, and also for the retrieval of a value from a specific place in the list. The concrete implementations -- i.e., how the list is actually programmed -- has beed abstracted behind the methods, so that a programmer making use of a list doesn't need to concern themselves with its inner workings.
+ArrayList is a pre-made tool in Java that helps dealing with lists. It offers various methods, including ones for adding values to the list, removing values from it, and also for the retrieval of a value from a specific place in the list. The concrete implementations -- i.e., how the list is actually programmed -- has been abstracted behind the methods, so that a programmer making use of a list doesn't need to concern themselves with its inner workings.
 
 <!-- ## Listan käyttöönotto ja luominen -->
 


### PR DESCRIPTION
how the list is actually programmed -- has **beed** abstracted

to

how the list is actually programmed -- has **been** abstracted
![beed typo](https://user-images.githubusercontent.com/27398127/151770346-14cb6803-fdd5-4b41-87e5-5865169fe87e.jpg)
