### PR TITLE
Fixing a typo in the course material

### DIFF
--- a/data/part-13/5-multiple-views.md
+++ b/data/part-13/5-multiple-views.md
@@ -14,9 +14,9 @@ hidden: false
 
 <text-box variant='learningObjectives' name='Learning Objectives'>
 
-- You proctice adding multiple views to a graphical interface.
+- You practise adding multiple views to a graphical interface.
 - You know methods for changing the view.
-- You know methods for separating the application logic and the user interface logic
+- You know methods for separating the application logic and the user interface logic.
 
 </text-box>
 


### PR DESCRIPTION
Fixed a typo in /rage/java-programming/tree/master/data/part-13)/5-multiple-views.md by correcting the misspelled word "proctice" to "practise" and also added a full stop at the end of the description in the "Learning Objectives" section.