### PR TITLE
no more exams

### DIFF
--- a/data/grading-and-exams.md
+++ b/data/grading-and-exams.md
@@ -6,7 +6,7 @@ information_page: true
 ---
 
 ## Java Programming MOOC
-<strong>No more exams will be held on this course.</strong> You can receive a certificate upon completing at least 80% of exercises per part. The certificates are seperate for Java Programming I and Java Programming II.
+**No more exams will be held on this course.** You can receive a certificate upon completing at least 80% of exercises per part. The certificates are seperate for Java Programming I and Java Programming II.
 
 ## Python Programming MOOC
 The current official MOOC course is [Python Programming MOOC 2022](https://programming-22.mooc.fi), for which it is possible for [residents of Finland](https://programming-22.mooc.fi/faq#can-i-receive-official-study-credits-for-this-course) to get 5+5 ECTS credits from the University of Helsinki. For non-residents there is also a certificate available after the exam.

--- a/data/grading-and-exams.md
+++ b/data/grading-and-exams.md
@@ -5,8 +5,11 @@ hidden: false
 information_page: true
 ---
 
-<notice><strong>No more exams will be held on this course.</strong> You can receive a certificate upon completing at least 80% of exercises per part. The certificates are seperate for Java Programming I and Java Programming II.</notice>
+<strong>No more exams will be held on this course.</strong> You can receive a certificate upon completing at least 80% of exercises per part. The certificates are seperate for Java Programming I and Java Programming II.
 
+The current official MOOC course is [Python Programming MOOC 2022](https://programming-22.mooc.fi), for which it is possible for residents of Finland to get 5+5 ECTS credits from the University of Helsinki.
+
+<!--
 The Java Programming MOOC contains University of Helsinki's courses Introduction to Programming (parts 1-7) and Advanced Course in Programming (parts 8-14). A free online exam will be held for both parts and both will be graded seperately.
 
 The exam corresponding to Introduction to Programming is to be completed after parts 1-7. Likewise, the exam corresponding to Advanced Course in Programming is to be completed after parts 8-14.
@@ -71,7 +74,7 @@ You may attend the exam once you have gotten at least 25% of each part's program
 ##### Minimum point treshold
 
 To pass each course you must receive at least half of the corresponding exam's points.
-
+-->
 <!--
 
 Arvostelu toimii seuraavasti:

--- a/data/grading-and-exams.md
+++ b/data/grading-and-exams.md
@@ -5,10 +5,10 @@ hidden: false
 information_page: true
 ---
 
-# Java Programming MOOC
+## Java Programming MOOC
 <strong>No more exams will be held on this course.</strong> You can receive a certificate upon completing at least 80% of exercises per part. The certificates are seperate for Java Programming I and Java Programming II.
 
-# Python Programming MOOC
+## Python Programming MOOC
 The current official MOOC course is [Python Programming MOOC 2022](https://programming-22.mooc.fi), for which it is possible for [residents of Finland](https://programming-22.mooc.fi/faq#can-i-receive-official-study-credits-for-this-course) to get 5+5 ECTS credits from the University of Helsinki. For non-residents there is also a certificate available after the exam.
 
 <!--

--- a/data/grading-and-exams.md
+++ b/data/grading-and-exams.md
@@ -7,7 +7,7 @@ information_page: true
 
 <strong>No more exams will be held on this course.</strong> You can receive a certificate upon completing at least 80% of exercises per part. The certificates are seperate for Java Programming I and Java Programming II.
 
-The current official MOOC course is [Python Programming MOOC 2022](https://programming-22.mooc.fi), for which it is possible for residents of Finland to get 5+5 ECTS credits from the University of Helsinki.
+The current official MOOC course is [Python Programming MOOC 2022](https://programming-22.mooc.fi), for which it is possible for [residents of Finland](https://programming-22.mooc.fi/faq#can-i-receive-official-study-credits-for-this-course) to get 5+5 ECTS credits from the University of Helsinki.
 
 <!--
 The Java Programming MOOC contains University of Helsinki's courses Introduction to Programming (parts 1-7) and Advanced Course in Programming (parts 8-14). A free online exam will be held for both parts and both will be graded seperately.

--- a/data/grading-and-exams.md
+++ b/data/grading-and-exams.md
@@ -5,9 +5,11 @@ hidden: false
 information_page: true
 ---
 
+# Java Programming MOOC
 <strong>No more exams will be held on this course.</strong> You can receive a certificate upon completing at least 80% of exercises per part. The certificates are seperate for Java Programming I and Java Programming II.
 
-The current official MOOC course is [Python Programming MOOC 2022](https://programming-22.mooc.fi), for which it is possible for [residents of Finland](https://programming-22.mooc.fi/faq#can-i-receive-official-study-credits-for-this-course) to get 5+5 ECTS credits from the University of Helsinki.
+# Python Programming MOOC
+The current official MOOC course is [Python Programming MOOC 2022](https://programming-22.mooc.fi), for which it is possible for [residents of Finland](https://programming-22.mooc.fi/faq#can-i-receive-official-study-credits-for-this-course) to get 5+5 ECTS credits from the University of Helsinki. For non-residents there is also a certificate available after the exam.
 
 <!--
 The Java Programming MOOC contains University of Helsinki's courses Introduction to Programming (parts 1-7) and Advanced Course in Programming (parts 8-14). A free online exam will be held for both parts and both will be graded seperately.

--- a/data/grading-and-exams.md
+++ b/data/grading-and-exams.md
@@ -5,6 +5,8 @@ hidden: false
 information_page: true
 ---
 
+<notice><strong>No more exams will be held on this course.</strong> You can receive a certificate upon completing at least 25% of exercises per part. The certificates are seperate for Java Programming I and Java Programming II.</notice>
+
 The Java Programming MOOC contains University of Helsinki's courses Introduction to Programming (parts 1-7) and Advanced Course in Programming (parts 8-14). A free online exam will be held for both parts and both will be graded seperately.
 
 The exam corresponding to Introduction to Programming is to be completed after parts 1-7. Likewise, the exam corresponding to Advanced Course in Programming is to be completed after parts 8-14.
@@ -13,19 +15,9 @@ Both exams will be held on several different days. You can attend the exam on an
 
 ## Upcoming exams
 
-**Detailed information on the upcomping exam can be found here: [https://java-programming.mooc.fi/exam](https://java-programming.mooc.fi/exam)**
+**There are no upcoming exams.**
 
-#### Introduction To Programming
-
-* ~~22.08.2020~~ canceled
-* 29.08.2020
-* Final exam January 15th, 2021
-
-#### Advanced Course In Programming
-
-* ~~29.08.2020~~ canceled
-* 05.09.2020
-* Final exam January 16th, 2021
+The final exam was in January 2021.
 
 ## Points
 

--- a/data/grading-and-exams.md
+++ b/data/grading-and-exams.md
@@ -5,7 +5,7 @@ hidden: false
 information_page: true
 ---
 
-<notice><strong>No more exams will be held on this course.</strong> You can receive a certificate upon completing at least 25% of exercises per part. The certificates are seperate for Java Programming I and Java Programming II.</notice>
+<notice><strong>No more exams will be held on this course.</strong> You can receive a certificate upon completing at least 80% of exercises per part. The certificates are seperate for Java Programming I and Java Programming II.</notice>
 
 The Java Programming MOOC contains University of Helsinki's courses Introduction to Programming (parts 1-7) and Advanced Course in Programming (parts 8-14). A free online exam will be held for both parts and both will be graded seperately.
 

--- a/data/index.md
+++ b/data/index.md
@@ -24,4 +24,5 @@ The course is split up into two individual courses: Java Programming I and Java 
 
 ## Credits and certificate
 
-If you have a Finnish social security number you can get official study credits from the Open University of University of Helsinki if you take an exam after the course. If you don't have a Finnish social security number you can get a certificate after completing the course from here: https://www.mooc.fi/en/profile/completions.
+No more exams will be held on this course. If you have a Finnish social security number and wish to complete Introduction to Programming and the Advanced Course in Programming for credits, see [Python Programming MOOC](https://programming-22.mooc.fi).  
+You can get a certificate for each course (Java Programming I & Java Programming II seperately) from here: https://www.mooc.fi/en/profile/completions.

--- a/data/part-7/4-introduction-to-programming.md
+++ b/data/part-7/4-introduction-to-programming.md
@@ -1,6 +1,6 @@
 ---
 path: '/part-7/4-java-programming'
-title: 'Summary and about exam'
+title: 'Conclusion'
 hidden: false
 ---
 
@@ -17,6 +17,6 @@ During the first seven parts you've become familiar with the basics of programmi
 
 The journey continues with the Java Programming II Course, which begins with part 8 of the material.
 
-**Note!** Completing this part ends the first part of this course, Java Programming I, which runs from parts 1-7. If you reside in Finland, you can participate on  a course exam worth 5 ECTS is done once part 7 has been completed.
+**Note!** Completing this part ends the first part of this course, Java Programming I, which runs from parts 1-7. You may request a certificate from here: https://www.mooc.fi/en/profile/completions
 
 <quiz id="a343e0af-8203-44a1-adce-d7d220813576"></quiz>

--- a/data/part-7/index.md
+++ b/data/part-7/index.md
@@ -9,10 +9,10 @@ hidden: false
 
 In the seventh part of the course we'll focus on general programming paradigms and algorithms. The course Introduction to programming (TKT-10002) ends after the seventh week, and the Advanced course in programming (TKT-10003) begins with the eight part.
 
-
+<!--
 <text-box variant="hint" name="Getting ECTS credits from Open University of University of Helsinki">
 
-If you **reside in Finland and want to get 5 ECTS credits from parts 1-7 from the Open University of University of Helsinki**, you'll need to participate in a course exam. 
+If you **reside in Finland and want to get 5 ECTS credits from parts 1-7 from the Open University of University of Helsinki**, you'll need to participate in a course exam.
 
 The first exam is on March 21st. The exam procedure is described below:
 
@@ -20,7 +20,7 @@ The exam can be found at this page on March 21st 2020 at 08:00:
 
 <a href="https://exams.mooc.fi/en">https://exams.mooc.fi/en</a>
 
-* You have four hours to complete the exam. If extra time is provided to you by University of Helsinki, you have five hours. 
+* You have four hours to complete the exam. If extra time is provided to you by University of Helsinki, you have five hours.
 * The exam ends at 22.00 (10pm). If you want to spend full 4 hours in the exam, start it at 18:00 the latest.
 * The exam time starts running when you open the exam. Submissions outside the exam time will not be considered.
 * You can log in to exam site with you mooc.fi credentials.
@@ -31,6 +31,7 @@ The exam can be found at this page on March 21st 2020 at 08:00:
 * The results are sent to your email with instructions on how to collect the credits. You should give us up to 6 weeks to grade the exams. Again, please note that credits can only be provided to residents of Finland.
 
 </text-box>
+-->
 
 <please-login></please-login>
 


### PR DESCRIPTION
Affected pages:
\- Updated: https://programming-20-git-concernedhobbit-patch-1-mooc.vercel.app/grading-and-exams
\- Current: https://java-programming.mooc.fi/grading-and-exams

\- Updated: https://programming-20-git-concernedhobbit-patch-1-mooc.vercel.app/
\- Current: https://java-programming.mooc.fi

\- Updated: https://programming-20-git-concernedhobbit-patch-1-mooc.vercel.app/part-7
\- Current: https://java-programming.mooc.fi/part-7

\- Updated: https://programming-20-git-concernedhobbit-patch-1-mooc.vercel.app/part-7/4-java-programming
\- Current: https://java-programming.mooc.fi/part-7/4-java-programming


Since this is an ongoing open course, make it clear that no more exams will be held. Remove old, unnecessary info but preserve grading details for future reference.