### PR TITLE
Add Discord and update links to Python MOOC

### DIFF
--- a/data/grading-and-exams.md
+++ b/data/grading-and-exams.md
@@ -9,7 +9,7 @@ information_page: true
 **No more exams will be held on this course.** You can receive a certificate upon completing at least 80% of exercises per part. The certificates are seperate for Java Programming I and Java Programming II.
 
 ## Python Programming MOOC
-The current official MOOC course is [Python Programming MOOC 2022](https://programming-22.mooc.fi), for which it is possible to get 5+5 ECTS credits from the University of Helsinki. There is also a certificate available after the exam.
+The current official MOOC course is [Python Programming MOOC 2023](https://programming-23.mooc.fi), for which it is possible to get 5+5 ECTS credits from the University of Helsinki. There is also a certificate available after the exam.
 
 <!--
 The Java Programming MOOC contains University of Helsinki's courses Introduction to Programming (parts 1-7) and Advanced Course in Programming (parts 8-14). A free online exam will be held for both parts and both will be graded seperately.

--- a/data/index.md
+++ b/data/index.md
@@ -24,6 +24,6 @@ The course is split up into two individual courses: Java Programming I and Java 
 
 ## Credits and certificate
 
-No more exams will be held on this course. If you wish to complete Introduction to Programming and the Advanced Course in Programming for credits, see [Python Programming MOOC](https://programming-22.mooc.fi).
+No more exams will be held on this course. If you wish to complete Introduction to Programming and the Advanced Course in Programming for credits, see [Python Programming MOOC](https://programming-23.mooc.fi).
 
 You can get a certificate for each course (Java Programming I & Java Programming II seperately) from here: https://www.mooc.fi/en/profile/completions.

--- a/data/support-and-assistance.md
+++ b/data/support-and-assistance.md
@@ -5,20 +5,19 @@ hidden: false
 information_page: true
 ---
 
-## Chat channel
+## Discord
 
-<notice>This course does not have a channel in the Department of Computer Science Discord. Support is only offered on a volunteer basis in the Telegram group.</notice>
+<notice>The Department of Computer Science provides no guidance for this course. Support is offered on a volunteer basis on the Discord channel.</notice>
 
-The course has a support chat channel in Telegram. We suggest that you use the channel either with Telegram's web browser client or with Telegram's desktop application.
+Discord is a communication platform which allows both text-based and voice/video chats. You can find out more about the platform on the [Discord website](https://discord.com/).
 
-You can join the channel through this link: [https://t.me/java\_programming\_mooc](https://t.me/java_programming_mooc)
-You can access the web browser client here: [https://web.telegram.org](https://web.telegram.org/)
-
-There's also an off-topic channel for conversation that isn't directly connected to the course: [https://t.me/java\_programming\_mooc\_ot](https://t.me/java_programming_mooc_ot)
+The course channel is available [through this link](https://study.cs.helsinki.fi/discord/join/java).
 
 The participants in the channel are fellow students and volunteer course assistants. The channel's activity is based on voluntary assistance. Please also help other students on the channel when you can.
 
-If you ask for help in the channel, you may add a link to your program code. You can get a link to your code in NetBeans by pressing "`TMC`" --> "`Send code to pastebin`" and then selecting "`Send`" from the opened view. After you've sent the code, a new view should show up with the link to your code, which you can then share on the channel when you're asking for help.
+There's also an off-topic channel for conversation that isn't directly connected to the course: [https://t.me/java\_programming\_mooc\_ot](https://t.me/java_programming_mooc_ot)
+
+We recommend all users in the course Telegram channel to join the Discord.
 
 ## Email
 


### PR DESCRIPTION
- Telegram links replaced with Discord link.
- Python MOOC 2022 links replaced with Python MOOC 2023 links.