### PR TITLE
Fix typo

### DIFF
--- a/data/part-6/1-objects-within-objects.md
+++ b/data/part-6/1-objects-within-objects.md
@@ -2110,7 +2110,7 @@ public class Main {
 ```java
 public class Main {
     public static void main(String[] args) {
-        Item book = new Item("The lord of the rings", 2);
+        Item book = new Item("Lord of the rings", 2);
         Item phone = new Item("Nokia 3210", 1);
 
         System.out.println("The book's name: " + book.getName());


### PR DESCRIPTION
In section 6 subsection 1 (https://java-programming.mooc.fi/part-6/1-objects-within-objects) there is a typo where an item is created as "The lord of the rings", but later referenced as "Lord of the rings". This PR changes the one instance of "The lord of the rings" to match the others.