### PR TITLE
Fix typo

### DIFF
--- a/data/part-11/2-packages.md
+++ b/data/part-11/2-packages.md
@@ -271,7 +271,7 @@ Within the exercise base, create three packages: `a`, `b`, and `c`. Create class
 
 <!-- Projektin hakemistossa `src/main/java` on ohjelmaan liittyvät lähdekoodit. Jos luokan pakkauksena on kirjasto, sijaitsee luokka projektin lähdekoodihakemiston `src/main/java/kirjasto`-kansiossa. NetBeansissa voi käydä katsomassa projektien konkreettista rakennetta **Files**-välilehdeltä joka on normaalisti **Projects**-välilehden vieressä. Jos et näe välilehteä **Files**, saa sen näkyville valitsemalla vaihtoehdon **Files** valikosta **Window**. -->
 
-The project directory `src/main/java` contains the source code files of the program. If the package of a class is library, that class is stored inside the `src/main/java/libary` folder of the source code directory. You can also check the concrete project structure in NetBeans in the **Files** tab, which is normally next to the **Project** tab. If you cannot see the **Files** tab, you can make it appear by choosing the option **Files** from the dropdown menu **Window**.
+The project directory `src/main/java` contains the source code files of the program. If the package of a class is library, that class is stored inside the `src/main/java/library` folder of the source code directory. You can also check the concrete project structure in NetBeans in the **Files** tab, which is normally next to the **Project** tab. If you cannot see the **Files** tab, you can make it appear by choosing the option **Files** from the dropdown menu **Window**.
 
 <!-- Sovelluskehitystä tehdään normaalisti **Projects**-välilehdeltä, jossa NetBeans on piilottanut projektiin liittyviä tiedostoja joista ohjelmoijan ei tarvitse välittää. -->
 


### PR DESCRIPTION
There is a typo under **Part 11 - Packages**.

Before:
![image](https://github.com/rage/java-programming/assets/100833190/b7b488cb-b609-49cd-976b-579137857ac8)

After:
![image](https://github.com/rage/java-programming/assets/100833190/39212b32-8ceb-43b4-92a4-ac4b95ed7a4a)

