### PR TITLE
Fixed typos and punctuations in Java Programming I: Part 3, Lists  (Updated 2-lists.md)

### DIFF
--- a/data/part-3/2-lists.md
+++ b/data/part-3/2-lists.md
@@ -1269,7 +1269,7 @@ The exercise template contains a base that reads numbers from the user and adds 
 
 <!-- Lisää ohjelmaan toiminnallisuus, joka lukujen lukemisen jälkeen kysyy käyttäjältä alkuindeksiä ja loppuindeksiä. Tämän jälkeen ohjelman tulostaa listalla olevat luvut käyttäjän syöttämien indeksien välillä. Voit olettaa, että käyttäjä syöttää indeksit, jotka löytyvät listalta. -->
 
-Expand the program to ask for a start and end indices once it has finished asking for numbers. After this the program shall prints all the numbers in the list that fall in the specified range (between the indices given by the user, inclusive). You may assume that the user gives indices that match some numbers in the list.
+Expand the program to ask for start and end indices once it has finished asking for numbers. After this, the program shall print all the numbers in the list that fall within the specified range (between the indices given by the user, inclusive). You may assume that the user gives indices that match some numbers in the list.
 
 <!--
 <sample-output>


### PR DESCRIPTION
Fixed the typo and punctuation of 2-lists.md 
Java Programming I: Part 3, Lists
Programming exercise: Only these numbers