### PR TITLE
docs: fix typo in 4-methods.md

### DIFF
--- a/data/part-2/4-methods.md
+++ b/data/part-2/4-methods.md
@@ -27,7 +27,7 @@ Printing to the screen has been done with the statement `System.out.println()`, 
 
 <!-- Teknisesti ottaen **metodi** tarkoittaa nimettyä lauseista koostuvaa joukkoa, eli ohjelman palaa, jota voi kutsua muualta ohjelmakoodista metodille annetun nimen perusteella. Esimerkiksi koodirivillä `System.out.println("olen metodille annettava parametri!")` kutsutaan metodia, joka suorittaa ruudulle tulostamisen. Metodin sisäinen toteutus -- eli joukko suoritettavia lauseita -- on piilossa, eikä ohjelmoijan tarvitse välittää siitä metodia käytettäessä. -->
 
-Technically speaking, **a method** is a named set of statements. It's a piece of a program that can be called from elsewhere in the code by the name given to the method. For instance `System.out.println("I am a parameter given to the method!")` calls a methods that performs printing to the screen. The internal implementation of the method -- meaning the set of statements to be executed -- is hidden, and the programmer does not need to concern themselves with it when using the method.
+Technically speaking, **a method** is a named set of statements. It's a piece of a program that can be called from elsewhere in the code by the name given to the method. For instance `System.out.println("I am a parameter given to the method!")` calls a method that performs printing to the screen. The internal implementation of the method -- meaning the set of statements to be executed -- is hidden, and the programmer does not need to concern themselves with it when using the method.
 
 <!-- Tähän mennessä käyttämämme metodit ovat kaikki olleet Javan valmiita metodeita. Opetellaan seuraavaksi tekemään omia metodeita. -->
 

--- a/data/part-2/4-methods.md
+++ b/data/part-2/4-methods.md
@@ -44,7 +44,7 @@ So far all the methods we have used have been ready-made Java methods. Next we w
 
 <!-- Metodit kirjoitetaan ohjelmarunkoon `main`:in aaltosulkeiden ulkopuolelle mutta kuitenkin "uloimmaisten" aaltosulkeiden sisäpuolelle, joko mainin ylä- tai alapuolelle. -->
 
-In the code boilerplate, methods are written outside of the curly braces of the `main`, yet inside out the "outermost" curly braces. They can be located above or below the main.
+In the code boilerplate, methods are written outside of the curly braces of `main`, yet within the "outermost" curly braces. They can be located either above or below `main`.
 
 <!-- ```java
 import java.util.Scanner;


### PR DESCRIPTION
- Fix typo _"calls a methods"_ to _"calls a method"_
- Fix a typographical error and improved terminology in the description of method placement in code. Changed _"inside out"_ to _"within"_ for clarity, and adjusted the reference from _"the main"_ to _"main"_ to align with common programming language usage.
