### PR TITLE
Fix surface area output & book search syntax in Part 8 examples

### DIFF
--- a/data/part-5/1-learning-object-oriented-programming.md
+++ b/data/part-5/1-learning-object-oriented-programming.md
@@ -715,7 +715,7 @@ System.out.println(first.surfaceArea());
 (40, 80)
 (10, 10)
 (39, 80)
-3920
+3120
 
 </sample-output>
 

--- a/data/part-8/2-hash-map.md
+++ b/data/part-8/2-hash-map.md
@@ -713,7 +713,7 @@ public class Library {
     }
 
     public void addBook(Book book) {
-        String name = book.getName()
+        String name = book.getName();
         if (name == null) {
             name = "";
         }

--- a/data/part-8/2-hash-map.md
+++ b/data/part-8/2-hash-map.md
@@ -402,7 +402,7 @@ books.add(prideAndPrejudice);
 // searching for a book named Sense and Sensibility
 Book match = null;
 for (Book book: books) {
-    if (book.getName().equals("Sense and Sensibility") {
+    if (book.getName().equals("Sense and Sensibility")) {
         match = book;
         break;
     }


### PR DESCRIPTION
Corrected the miscalculation in the sample output for the Rectangle class example. Before, the area of rectangle with width 39 & height 80 was 3920. The correct answer is 3120.

### Change Made
- Update the sample output into correct surface area calculation (3120 instead of 3920).
