### PR TITLE
fix typo : part 5_4-objects-and-references.md

### DIFF
--- a/data/part-5/4-objects-and-references.md
+++ b/data/part-5/4-objects-and-references.md
@@ -1242,9 +1242,9 @@ rahaa 2.0
 <sample-output>
 
 money 10.0
-successfully took: true
+successfully withdrew: true
 money 2.0
-successfully took: false
+successfully withdrew: false
 money 2.0
 
 </sample-output>


### PR DESCRIPTION
 # FIx Typo in [Part 5](https://java-programming.mooc.fi/part-5/4-objects-and-references)
changed ```took -> withdrew``` 

refer to image for clarity : 

![image](https://github.com/user-attachments/assets/e291cea0-fe6b-45ee-b775-ee48bc495721)