### PR TITLE
Fix typos in course material (Part 14 + Part 3)

### DIFF
--- a/data/part-14/3-larger-application-asteroids.md
+++ b/data/part-14/3-larger-application-asteroids.md
@@ -828,7 +828,7 @@ new AnimationTimer() {
 
 <!-- Alus liikkuu, mutta aluksen liikettä ei voi vielä muuttaa. Lisätään alukselle kiihdytystoiminnallisuus. Kiihdytyksen tulee toimia niin, että aluksen nopeus kiihtyy aluksen osoittamaan suuntaan. Saamme kiihdytyksen monikulmion asteesta, jonka saa selville metodilla `getRotate()`. Olemme käyttäneet tätä jo paljon alusta kääntäessä. -->
 
-The ship moves, but it's not possible to affect the movement yet. Let's add an acceleration functionality to the shpi. The ship should accelerate so that the speed accelerates to the direction that the ship points to. We can get the acceleration information from the rotation degree, which we can use the `getRotate()` method. We have already become well acquainted with it in rotating the ship.
+The ship moves, but it's not possible to affect the movement yet. Let's add an acceleration functionality to the ship. The ship should accelerate so that the speed accelerates to the direction that the ship points to. We can get the acceleration information from the rotation degree, which we can use the `getRotate()` method. We have already become well acquainted with it in rotating the ship.
 
 <!-- Kiihdytyksen suunta saadaan selville sini- ja kosinifunktion avulla. Nämä löytyvät Javan valmiista [Math](https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html)-luokasta. Metodit saavat parametrina asteen radiaaneina, joten joudumme hyödyntämään myös Math-luokan asteiden radiaaneiksi muuttavaa metodia. -->
 

--- a/data/part-3/4-strings.md
+++ b/data/part-3/4-strings.md
@@ -146,7 +146,7 @@ NB! The program should ask for only one string. Don't use a loop here.
 ## String Comparisons And "Equals"
 
 <!-- Merkkijonoja ei voi vertailla yhtäsuuri kuin operaatiolla `==`.  Merkkijonojen vertailuun käytetään erillistä `equals`-komentoa, joka liittyy aina verrattavaan merkkijonoon. -->
-Strings can't be compared with with the equals operator - `==`. For strings, there exists a separate `equals`-command, which is always appended to the end of the string that we want to compare.
+Strings can't be compared with the equals operator - `==`. For strings, there exists a separate `equals`-command, which is always appended to the end of the string that we want to compare.
 
 <!-- ```java
 String teksti = "kurssi";


### PR DESCRIPTION
This PR fixes minor typos in the Java Programming MOOC course material.

- **Part 14:** Corrected "shpi" → "ship".
- **Part 3:** Removed repeated words in 4-strings.md for clarity.

These are minor textual corrections to improve readability and accuracy.