### PR TITLE
fix: correct output value in Java Programming I (Part 5.1, line 718)

### DIFF
--- a/data/part-5/1-learning-object-oriented-programming.md
+++ b/data/part-5/1-learning-object-oriented-programming.md
@@ -715,7 +715,7 @@ System.out.println(first.surfaceArea());
 (40, 80)
 (10, 10)
 (39, 80)
-3920
+3120
 
 </sample-output>
 


### PR DESCRIPTION
Corrected output value in line 718 from `3920` to `3120` as per expected result in the Java Programming I class section (Part 5.1). This change ensures correct output and improves accuracy for learners.