### PR TITLE
Corrected wording from 'parameter' to 'argument'

### DIFF
--- a/data/part-1/3-reading-input.md
+++ b/data/part-1/3-reading-input.md
@@ -262,7 +262,7 @@ Hi Ada Lovelace!
 </sample-output>
 
 <!-- Huom! Kun käytät `System.out.println`-komentoa, älä kirjoita komentoon merkkijonoa "Ada Lovelace", vaan hyödynnä tulostuksessa olemassaolevaa muuttujaa `nimi`: `System.out.println("Hei " + ...)`. -->
-NB! When using the `System.out.println` command, do not pass in the string "Ada Lovelace" as a parameter. Instead, use the existing variable `name`: `System.out.println("Hi " + ...)`
+NB! When using the `System.out.println` command, do not pass in the string "Ada Lovelace" as a argument. Instead, use the existing variable `name`: `System.out.println("Hi " + ...)`
 
 </programming-exercise>
 


### PR DESCRIPTION
## Description

Updated the documentation to use the correct Java terminology.

### Changes Made

* Replaced the term **"parameter"** with **"argument"** in the exercise instructions.
* This aligns the documentation with standard Java terminology, where values passed to a method call are called arguments, while parameters are the variables defined in the method signature.

### Reason

The previous wording could be confusing for learners because it referred to the value passed to `System.out.println(...)` as a parameter. Using the term **argument** makes the explanation more accurate and educational.
